### PR TITLE
Make README snippets less likely to trigger IDE errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Follow the steps on [the Google documentation](https://developers.google.com/ide
 // app/services/auth.server.ts
 import { GoogleStrategy } from 'remix-auth-google'
 
-let googleStrategy = new GoogleStrategy(
+const googleStrategy = new GoogleStrategy(
   {
     clientID: 'YOUR_CLIENT_ID',
     clientSecret: 'YOUR_CLIENT_SECRET',
@@ -44,6 +44,8 @@ authenticator.use(googleStrategy)
 
 ```tsx
 // app/routes/login.tsx
+import { Form } from "@remix-run/react";
+
 export default function Login() {
   return (
     <Form action="/auth/google" method="post">
@@ -58,9 +60,9 @@ export default function Login() {
 import { ActionArgs } from '@remix-run/node'
 import { authenticator } from '~/services/auth.server'
 
-export let loader = () => redirect('/login')
+export const loader = () => redirect('/login')
 
-export let action = ({ request }: ActionArgs) => {
+export const action = ({ request }: ActionArgs) => {
   return authenticator.authenticate('google', request)
 }
 ```
@@ -70,7 +72,7 @@ export let action = ({ request }: ActionArgs) => {
 import { LoaderArgs } from '@remix-run/node'
 import { authenticator } from '~/services/auth.server'
 
-export let loader = ({ request }: LoaderArgs) => {
+export const loader = ({ request }: LoaderArgs) => {
   return authenticator.authenticate('google', request, {
     successRedirect: '/dashboard',
     failureRedirect: '/login',

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ export const action = ({ request }: ActionFunctionArgs) => {
 
 ```tsx
 // app/routes/auth/google/callback.tsx
-import { LoaderArgs } from '@remix-run/node'
+import { LoaderFunctionArgs } from '@remix-run/node'
 import { authenticator } from '~/services/auth.server'
 
-export const loader = ({ request }: LoaderArgs) => {
+export const loader = ({ request }: LoaderFunctionArgs) => {
   return authenticator.authenticate('google', request, {
     successRedirect: '/dashboard',
     failureRedirect: '/login',

--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ export default function Login() {
 
 ```tsx
 // app/routes/auth/google.tsx
-import { ActionArgs } from '@remix-run/node'
+import { ActionFunctionArgs, redirect } from '@remix-run/node'
 import { authenticator } from '~/services/auth.server'
 
 export const loader = () => redirect('/login')
 
-export const action = ({ request }: ActionArgs) => {
+export const action = ({ request }: ActionFunctionArgs) => {
   return authenticator.authenticate('google', request)
 }
 ```


### PR DESCRIPTION
- Most linters (e.g. ESLint) enforce that variables are declared with `const` if they aren't reassigned
- A bit more specific about the login page's import (`<Form>` is sometimes provided in UI libraries, but we want the Remix one)
- Imports changed in newer versions of Remix